### PR TITLE
importando dotenv.config nos arquivos necessários

### DIFF
--- a/server/knexfile.js
+++ b/server/knexfile.js
@@ -1,4 +1,5 @@
 const path = require('path');
+require('dotenv').config();
 module.exports = {
 
   development: {

--- a/server/src/database/connection.js
+++ b/server/src/database/connection.js
@@ -1,5 +1,5 @@
 import knex from 'knex';
-
+require('dotenv').config();
 const connection = knex({
     client:'mysql',
     version:process.env.DB_VERSION,//OBS -> Versão no package.json!!


### PR DESCRIPTION
Resolvendo erro pontual.
Faltava importar a biblioteca dotenv aos arquivos que a utilizam.
require('dotenv').config()